### PR TITLE
Enabling Symfony/intl 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": ">=7.2",
     "ramsey/uuid": "~3.0",
-    "symfony/intl": "~3.4",
+    "symfony/intl": "~3.4 || ^4.0",
     "lambdish/phunctional": "^2.0"
   },
   "require-dev": {


### PR DESCRIPTION
Adding symfony/intl ^4 as a dependency so it could be supported in newer projects.